### PR TITLE
Update Badges in README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,10 +1,8 @@
 = Address Book (Level 3)
 ifdef::env-github,env-browser[:relfileprefix: docs/]
 
-https://travis-ci.org/se-edu/addressbook-level3[image:https://travis-ci.org/se-edu/addressbook-level3.svg?branch=master[Build Status]]
-https://ci.appveyor.com/project/damithc/addressbook-level3[image:https://ci.appveyor.com/api/projects/status/3boko2x2vr5cc3w2?svg=true[Build status]]
-https://coveralls.io/github/se-edu/addressbook-level3?branch=master[image:https://coveralls.io/repos/github/se-edu/addressbook-level3/badge.svg?branch=master[Coverage Status]]
-https://gitter.im/se-edu/Lobby[image:https://badges.gitter.im/se-edu/Lobby.svg[Gitter chat]]
+https://travis-ci.org/AY1920S1-CS2103T-T13-1/main[image:https://travis-ci.org/AY1920S1-CS2103T-T13-1/main.svg?branch=master[Build Status]]
+https://coveralls.io/github/AY1920S1-CS2103T-T13-1/main?branch=master[image:https://coveralls.io/repos/github/AY1920S1-CS2103T-T13-1/main/badge.svg?branch=master[Coverage Status]]
 
 ifdef::env-github[]
 image::docs/images/Ui.png[width="600"]


### PR DESCRIPTION
I added Netlify and coveralls for our applications. Now, everytime there is a change in our documentation you can check the latest documentation of the build by clicking the `Details` in the netflify check.

![image](https://user-images.githubusercontent.com/50859694/65570495-849f6e80-df8b-11e9-883d-ec79e8d98234.png)

 Also now the coverage badge, shows our app coverage and the build badge showing our team's build status instead of ab3.
